### PR TITLE
Add setup script and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Virtual environment
+.venv/
+venv/
+
+# Logs
+debug.log
+logs/
+
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # OneUserTool
+
+Dieses Projekt bietet eine einfache grafische Oberfläche auf Basis von PyQt5. Um die Anwendung zu starten, genügt es, das Skript `setup_and_start.sh` auszuführen. Das Skript erstellt bei Bedarf eine virtuelle Umgebung, installiert alle Abhängigkeiten aus `requirements.txt` und startet anschließend automatisch die GUI.
+
+## Schnellstart
+
+```bash
+./setup_and_start.sh
+```
+
+Für Fragen zum Umgang mit virtuellen Umgebungen oder bei Problemen siehe die Hinweise am Ende dieser Datei.
+
+## Hilfreiche Hinweise für Einsteiger
+
+* **Dateirechte:** Unter Linux muss das Skript ausführbar sein (`chmod +x setup_and_start.sh`).
+* **Fehlermeldungen bei der Installation:** Stellen Sie sicher, dass `python3` sowie die Paketverwaltung `pip` installiert sind.
+* **Virtuelle Umgebung löschen:** Möchten Sie das Projekt neu einrichten, können Sie einfach den Ordner `.venv` löschen und das Startskript erneut ausführen.

--- a/setup_and_start.sh
+++ b/setup_and_start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Setup virtual environment and launch GUI
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV="$DIR/.venv"
+PY="$VENV/bin/python"
+
+if [ ! -d "$VENV" ]; then
+  echo "[Info] Creating virtual environment..."
+  python3 -m venv "$VENV"
+fi
+
+source "$VENV/bin/activate"
+
+pip install --upgrade pip >/dev/null
+pip install -r "$DIR/requirements.txt" >/dev/null
+
+echo "[Info] Starting OneUserTool GUI..."
+exec "$PY" "$DIR/main.py"


### PR DESCRIPTION
## Summary
- add `.gitignore` for environment and logs
- create `setup_and_start.sh` to install dependencies and launch GUI automatically
- expand `README` with quickstart instructions and beginner tips

## Testing
- `python3 -m py_compile *.py`
- `bash setup_and_start.sh` *(fails: cannot install packages without internet)*

------
https://chatgpt.com/codex/tasks/task_e_685dba0aa9e483258358fc737dfe570e