### PR TITLE
Add Notizen module and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # OneUserTool
+
+A simple PyQt5 desktop application combining multiple small modules.
+
+## Requirements
+
+- Python 3.7 or newer
+- Dependencies listed in `requirements.txt`
+
+Install the dependencies in a virtual environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the Application
+
+You can start the tool directly using Python:
+
+```bash
+python3 main.py
+```
+
+Alternatively run the helper script which restarts the app after crashes:
+
+```bash
+bash start_oneusertool.sh
+```
+
+## Data Directory
+
+When running the tool it creates a `Projekt/` directory in the repository with
+these subfolders/files:
+
+```
+Projekt/
+├── Songtexte/          # gespeicherte Liedtexte
+├── Notizen/            # eigene Notizen
+└── genres_profile.json # Genre-Profile für mehrere Module
+```
+
+## Module Overview
+
+- **Songtexte** – Editor zum Anlegen und Verwalten von Songtexten.
+- **Genres** – Archiv für Genres inkl. Export-/Import-Optionen.
+- **Zufallsgenerator** – wählt zufällige Genres aus einem Profil aus.
+- **Notizen** – einfacher Texteditor zum Speichern von Notizen.
+
+Tipps für Einsteiger: probieren Sie zunächst das Genre-Archiv aus und
+experimentieren Sie mit eigenen Profilen. Nutzen Sie anschließend den
+Zufallsgenerator, um Inspiration für neue Songtexte oder Notizen zu sammeln.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# Version 0.1.7
+# Version 0.1.8
 import sys
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QWidget,
@@ -10,8 +10,9 @@ from design_manager import apply_stylesheet
 from songtext_modul import SongtextModul
 from genres_modul import GenresModul
 from zufallsgenerator_modul import ZufallsGeneratorModul
+from notizen_modul import NotizenModul
 
-VERSION = "0.1.7"
+VERSION = "0.1.8"
 
 class HauptModul(QMainWindow):
     def __init__(self):
@@ -24,7 +25,7 @@ class HauptModul(QMainWindow):
 
     def _build_ui(self):
         self.sidebar=QListWidget()
-        for name in ["Songtexte","Genres","Zufallsgenerator"]:
+        for name in ["Songtexte","Genres","Zufallsgenerator","Notizen"]:
             self.sidebar.addItem(name)
         self.sidebar.setFixedWidth(180)
         self.sidebar.itemClicked.connect(self._toggle_module)
@@ -34,6 +35,7 @@ class HauptModul(QMainWindow):
         self.stack.addWidget(SongtextModul())
         self.stack.addWidget(GenresModul())
         self.stack.addWidget(ZufallsGeneratorModul())
+        self.stack.addWidget(NotizenModul())
 
         header=QLabel(f"OneUserTool v{VERSION}")
         header.setAlignment(Qt.AlignCenter)
@@ -46,7 +48,7 @@ class HauptModul(QMainWindow):
         self.setCentralWidget(central)
 
     def _toggle_module(self,item):
-        idx={"Songtexte":1,"Genres":2,"Zufallsgenerator":3}[item.text()]
+        idx={"Songtexte":1,"Genres":2,"Zufallsgenerator":3,"Notizen":4}[item.text()]
         if self.stack.currentIndex()==idx:
             self.stack.setCurrentIndex(0); self.sidebar.clearSelection()
         else:

--- a/notizen_modul.py
+++ b/notizen_modul.py
@@ -1,0 +1,67 @@
+# Version 0.1.0
+import os, datetime
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QTextEdit,
+    QPushButton, QListWidget, QMenu, QMessageBox
+)
+from PyQt5.QtCore import Qt
+
+
+def dirpath():
+    base = os.path.dirname(os.path.abspath(__file__))
+    p = os.path.join(base, "Projekt", "Notizen")
+    os.makedirs(p, exist_ok=True)
+    return p
+
+
+class NotizenModul(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Notizen")
+        self.resize(500, 400)
+        v = QVBoxLayout(self)
+        v.addWidget(QLabel("Notiz:"))
+        self.te = QTextEdit()
+        v.addWidget(self.te)
+        v.addWidget(QPushButton("Speichern", clicked=self.save))
+        v.addWidget(QLabel("Gespeicherte Notizen:"))
+        self.lst = QListWidget()
+        self.lst.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.lst.customContextMenuRequested.connect(self.ctx)
+        v.addWidget(self.lst)
+        self.load()
+
+    def save(self):
+        txt = self.te.toPlainText().strip()
+        if not txt:
+            return
+        fn = datetime.datetime.now().strftime('%Y%m%d_%H%M%S.txt')
+        with open(os.path.join(dirpath(), fn), 'w', encoding='utf-8') as f:
+            f.write(txt)
+        self.te.clear()
+        self.load()
+
+    def load(self):
+        self.lst.clear()
+        for fn in sorted(os.listdir(dirpath()), reverse=True):
+            if fn.endswith('.txt'):
+                self.lst.addItem(fn)
+
+    def ctx(self, pos):
+        it = self.lst.itemAt(pos)
+        if not it:
+            return
+        menu = QMenu(self)
+        show = menu.addAction("Anzeigen")
+        delete = menu.addAction("Löschen")
+        ch = menu.exec_(self.lst.mapToGlobal(pos))
+        fp = os.path.join(dirpath(), it.text())
+        if ch == show:
+            with open(fp, 'r', encoding='utf-8') as f:
+                QMessageBox.information(self, it.text(), f.read())
+        elif ch == delete and QMessageBox.question(
+            self, "Löschen", f"{it.text()} löschen?",
+            QMessageBox.Yes | QMessageBox.No
+        ) == QMessageBox.Yes:
+            os.remove(fp)
+            self.load()


### PR DESCRIPTION
## Summary
- add simple Notizen module
- integrate Notizen module into main application
- document requirements, directory structure and modules in README

## Testing
- `python3 -m py_compile main.py songtext_modul.py genres_modul.py zufallsgenerator_modul.py notizen_modul.py design_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685dbd8bd2d88325a3f99ae1cb747a7b