### PR TITLE
Add configuration and module updater

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,10 @@
+# Configuration for OneUserTool update scripts
+# INSTALLDIR should point to the root directory where OneUserTool is installed.
+# Example path: /home/<user>/OneUserTool
+INSTALLDIR="/opt/OneUserTool"
+
+# MODULE_VERSION represents the version of the ModulesContainer component.
+# The component file should be located at modules/ModulesContainer.jsx
+# relative to this repository.
+MODULE_VERSION="1.0.0"
+

--- a/modules/ModulesContainer.jsx
+++ b/modules/ModulesContainer.jsx
@@ -1,0 +1,4 @@
+// Placeholder component
+export default function ModulesContainer() {
+  return null;
+}

--- a/update_modules_container.sh
+++ b/update_modules_container.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 # Load global config (INSTALLDIR, MODULE_VERSION)
-source "$(dirname "$0")/../config.sh"
+# The file should reside next to this script as "config.sh".
+source "$(dirname "$0")/config.sh"
 
 log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
 
@@ -61,9 +62,9 @@ fi
 # Copy updated component
 log "Installing updated ModulesContainer.jsx (Version $MODULE_VERSION)"
 if [[ "$DRY_RUN" == false ]]; then
-  cp "$(dirname "$0")/../modules/ModulesContainer.jsx" "$component_file"
+  cp "$(dirname "$0")/modules/ModulesContainer.jsx" "$component_file"
 else
-  echo "DRY RUN: cp $(dirname "$0")/../modules/ModulesContainer.jsx $component_file"
+  echo "DRY RUN: cp $(dirname "$0")/modules/ModulesContainer.jsx $component_file"
 fi
 
 log "Update complete. Please rebuild frontend if necessary."


### PR DESCRIPTION
## Summary
- introduce `config.sh` to store global variables
- update module updater to source `config.sh`
- add placeholder `ModulesContainer.jsx`

## Testing
- `bash update_modules_container.sh --install-dir $(pwd)/test_install --dry-run --yes`

------
https://chatgpt.com/codex/tasks/task_e_685dbdc64560832586f02b2156e19bdd