### PR TITLE
Refactor path handling for genre profiles

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,5 @@
+import os
+
+def genres_profile_path():
+    """Return absolute path to genres_profile.json inside the Projekt directory."""
+    return os.path.join(os.path.dirname(__file__), "Projekt", "genres_profile.json")

--- a/genres_modul.py
+++ b/genres_modul.py
@@ -1,5 +1,6 @@
 # Version 0.1.8
 import os, json, shutil
+from data_utils import genres_profile_path
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QLineEdit, QPushButton, QListWidget, QMessageBox, QComboBox,
@@ -8,11 +9,8 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QIcon
 from PyQt5.QtCore import Qt
 
-def data_path():
-    return os.path.join(os.path.dirname(__file__), "Projekt", "genres_profile.json")
-
 def load_profiles():
-    path = data_path()
+    path = genres_profile_path()
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
@@ -21,7 +19,7 @@ def load_profiles():
         return json.load(f) or {"Favoriten":[]}
 
 def save_profiles(d):
-    with open(data_path(), "w", encoding="utf-8") as f:
+    with open(genres_profile_path(), "w", encoding="utf-8") as f:
         json.dump(d, f, ensure_ascii=False, indent=2)
 
 class GenresModul(QWidget):

--- a/zufallsgenerator_modul.py
+++ b/zufallsgenerator_modul.py
@@ -1,16 +1,14 @@
 # Version 0.1.8
 import random, os, json
+from data_utils import genres_profile_path
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QComboBox, QListWidget, QMessageBox, QApplication
 )
 from PyQt5.QtCore import Qt
 
-def data_path():
-    return os.path.join(os.path.dirname(__file__), "Projekt", "genres_profile.json")
-
 def load_profiles():
-    path = data_path()
+    path = genres_profile_path()
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- add `data_utils.py` helper with `genres_profile_path`
- use helper in `genres_modul` and `zufallsgenerator_modul`

## Testing
- `python -m py_compile genres_modul.py zufallsgenerator_modul.py data_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685dbda5bb948325bae092de445697e9