### PR TITLE
Improve README with setup and usage info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # OneUserTool
+
+OneUserTool bündelt mehrere kleine Desktop-Module in einer Anwendung.
+
+## Module
+- **Songtext-Editor** (`songtext_modul.py`): Verfasst und verwaltet Songtexte im Ordner `Projekt/Songtexte`.
+- **Genre-Archiv** (`genres_modul.py`): Hält beliebig viele Genre-Profile in der Datei `Projekt/genres_profile.json`.
+- **Zufallsgenerator** (`zufallsgenerator_modul.py`): Wählt zufällige Genres aus einem Profil.
+- **Design Manager** (`design_manager.py`): Legt das Aussehen der Oberfläche fest.
+
+## Installation
+1. Python 3.7 oder neuer installieren.
+2. Abhängigkeiten via `requirements.txt` einrichten:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+## Start
+- Direkt per:
+  ```bash
+  python3 main.py
+  ```
+- Oder über das Skript `start_oneusertool.sh`, das Abstürze protokolliert und das virtuelle Environment nutzt.
+
+## Daten & Lizenz
+Alle erzeugten Dateien liegen im Unterordner `Projekt`. Dort befinden sich u.a. die Songtexte und die `genres_profile.json`.
+
+Die Software steht unter der [GNU General Public License v3.0](LICENSE).
+
+## Weiterführende Hinweise für Einsteiger
+- Unter Windows wird die virtuelle Umgebung mit `venv\Scripts\activate` aktiviert.
+- Legen Sie zuerst ein Genre-Profil an, damit der Zufallsgenerator arbeiten kann.
+- Export- und Backupfunktionen im Genre-Archiv erleichtern die Datensicherung.
+- Kopieren Sie Genres oder Songtexte in die Zwischenablage, um sie in anderen Programmen zu verwenden.


### PR DESCRIPTION
## Summary
- flesh out README with module overview, install instructions, and data notes
- add `.gitignore` for venv and bytecode

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dbd2eb0f88325ac39d3574f4b0e5a