### PR TITLE
Fix install path and env overrides

### DIFF
--- a/start_oneusertool.sh
+++ b/start_oneusertool.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-INSTALLDIR="/home/pppoppi/OneUserTool"
+# Default installation directory is the directory of this script. It can be
+# overridden by setting the INSTALLDIR environment variable before calling
+# this script.
+INSTALLDIR="${INSTALLDIR:-$(dirname "$(realpath "$0")")}"
 VENV_ACT="$INSTALLDIR/venv/bin/activate"
 MAIN_PY="$INSTALLDIR/main.py"
-LOGDIR="/home/pppoppi/OneUserTool/logs"
+LOGDIR="$INSTALLDIR/logs"
 RUNLOG="$LOGDIR/run.log"
 
 mkdir -p "$LOGDIR"


### PR DESCRIPTION
## Summary
- default INSTALLDIR to script location and allow overrides via env var
- use INSTALLDIR for log and Python path references

## Testing
- `python3 -m py_compile main.py design_manager.py genres_modul.py songtext_modul.py zufallsgenerator_modul.py`
- `bash -n start_oneusertool.sh`


------
https://chatgpt.com/codex/tasks/task_e_685dbd28885c8325a8ba0d54a764b366