### PR TITLE
Synchronize module versions

### DIFF
--- a/design_manager.py
+++ b/design_manager.py
@@ -1,4 +1,4 @@
-# Version 0.1.7
+# Version 0.1.8
 from PyQt5.QtWidgets import QApplication
 def apply_stylesheet(app, theme="dark", fontsize=16):
     if theme=="dark":

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# Version 0.1.7
+# Version 0.1.8
 import sys
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QWidget,
@@ -11,7 +11,7 @@ from songtext_modul import SongtextModul
 from genres_modul import GenresModul
 from zufallsgenerator_modul import ZufallsGeneratorModul
 
-VERSION = "0.1.7"
+VERSION = "0.1.8"
 
 class HauptModul(QMainWindow):
     def __init__(self):


### PR DESCRIPTION
## Summary
- bump version in `main.py` to 0.1.8
- sync module headers with version 0.1.8

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_685d9a765b788325856cbb3d8cf5cb6b