### PR TITLE
Add .gitignore for Python build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+oneusertool.log


### PR DESCRIPTION
## Summary
- add a simple `.gitignore` file

## Testing
- `python -m py_compile main.py`
- `python -m py_compile genres_modul.py songtext_modul.py zufallsgenerator_modul.py design_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_685dd985bc948325a49ff9ca7985e9a1