### PR TITLE
Improve config loading in update script

### DIFF
--- a/update_modules_container.sh
+++ b/update_modules_container.sh
@@ -5,7 +5,14 @@
 set -euo pipefail
 
 # Load global config (INSTALLDIR, MODULE_VERSION)
-source "$(dirname "$0")/../config.sh"
+# Check for config.sh before sourcing; exit with error if missing
+CONFIG_PATH="$(dirname "$0")/../config.sh"
+if [[ -f "$CONFIG_PATH" ]]; then
+  source "$CONFIG_PATH"
+else
+  echo "ERROR: Required config '$CONFIG_PATH' not found." >&2
+  exit 1
+fi
 
 log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
 


### PR DESCRIPTION
## Summary
- handle missing config.sh in `update_modules_container.sh`
- add comment explaining behavior

## Testing
- `bash -n update_modules_container.sh`
- `shellcheck update_modules_container.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd97dcdd08325945d71920ab84f91