### PR TITLE
Improve startup script, docs, and ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+
+# Virtual environment
+venv/
+.venv/
+
+# Logs and local data
+logs/
+*.log
+Projekt/
+
+# Build and packaging
+*.deb
+debian_pkg/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # OneUserTool
+
+OneUserTool ist eine kleine Desktop-Anwendung auf Basis von PyQt5. Sie verwaltet Songtexte, Genre-Profile und erzeugt zufällige Genre-Listen.
+
+## Einrichtung
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python3 main.py
+```
+
+## Debian-Paket bauen
+
+Eine einfache Paketierung ist möglich. Legen Sie dazu einen Ordner `debian_pkg` an, kopieren Sie den Projektinhalt hinein und erstellen Sie im Unterordner `DEBIAN` eine `control`-Datei. Mit `dpkg-deb --build debian_pkg` entsteht ein installierbares `.deb`-Paket.
+
+Weitere Hinweise finden Sie im Code und in den Shellskripten.

--- a/start_oneusertool.sh
+++ b/start_oneusertool.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-INSTALLDIR="/home/pppoppi/OneUserTool"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALLDIR="$SCRIPT_DIR"
 VENV_ACT="$INSTALLDIR/venv/bin/activate"
 MAIN_PY="$INSTALLDIR/main.py"
-LOGDIR="/home/pppoppi/OneUserTool/logs"
+LOGDIR="$INSTALLDIR/logs"
 RUNLOG="$LOGDIR/run.log"
 
 mkdir -p "$LOGDIR"


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore virtualenv, logs and build artifacts
- document setup and packaging steps in README
- make startup script work relative to its own location

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685ddb54c5288325ad5d2569526510c7