### PR TITLE
Add menu helper to start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # OneUserTool
+
+Dieses Projekt bietet ein kleines Bash-Skript zum Starten des Tools.
+
+## Start des Skripts
+
+```bash
+bash start_oneusertool.sh
+```
+
+Bei einem Absturz erscheint ein Menü. Wählen Sie die gewünschte Aktion,
+indem Sie die angezeigte Zahl eingeben und mit Enter bestätigen.
+
+## Tipps für Einsteiger
+
+* Stellen Sie sicher, dass Python und alle Abhängigkeiten installiert sind.
+* Die Logdatei finden Sie im Verzeichnis `logs/`. Sie hilft bei der Fehlersuche.
+* Sollten Probleme auftreten, starten Sie das Skript einfach erneut.

--- a/start_oneusertool.sh
+++ b/start_oneusertool.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+
+# Small helper to show a numbered menu and return the chosen index
+# Usage: select_option "prompt" "opt1" "opt2" ...
+# The function exits with the selected option number (starting at 0).
+select_option() {
+  local prompt=$1; shift
+  PS3="$prompt "
+  local options=("$@")
+  select opt in "${options[@]}"; do
+    if [ "$REPLY" -ge 1 ] && [ "$REPLY" -le "${#options[@]}" ]; then
+      return $((REPLY - 1))
+    fi
+    echo "Bitte eine Zahl aus der Liste wählen."
+  done
+}
+
 INSTALLDIR="/home/pppoppi/OneUserTool"
 VENV_ACT="$INSTALLDIR/venv/bin/activate"
 MAIN_PY="$INSTALLDIR/main.py"


### PR DESCRIPTION
## Summary
- add `select_option` helper in start_oneusertool.sh for crash menu
- explain how to use the menu in the README and offer newbie tips

## Testing
- `bash -n start_oneusertool.sh update_modules_container.sh`
- `python3 -m py_compile main.py genres_modul.py songtext_modul.py zufallsgenerator_modul.py design_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_685df1723cc48325a7936452ebe54186